### PR TITLE
Drop support for Node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,26 @@
 version: 2.1
-jobs:
-  build-common: &common-build
-    docker:
-      - image: node
+
+references:
+  x-workdir: &work-dir
     working_directory: ~/source
+
+  x-save-workspace: &persist-step
+    persist_to_workspace:
+      root: ~/source
+      paths:
+        - .
+
+  x-attach: &attach-step
+    attach_workspace:
+      at: .
+
+jobs:
+  install-dependencies:
+    <<: *work-dir
+    docker:
+      - image: circleci/node:10
+    environment:
+      HUSKY_SKIP_INSTALL: 1
     steps:
       - checkout
       - restore_cache:
@@ -19,42 +36,62 @@ jobs:
           key: v1-npm-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
+      - *persist-step
+
+  lint:
+    <<: *work-dir
+    docker:
+      - image: node
+    steps:
+      - *attach-step
       - run:
-          name: Lint
-          # ESLint only supports Node >=4
-          command: |
-            if node --version | grep -q '^v10'; then
-                npm run lint
-            fi
+          name: lint
+          command: npm run lint
+
+  node-10:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - *attach-step
       - run:
           name: Test
+          command: npm test
+
+  node-12:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - *attach-step
+      - run:
+          name: Test with coverage
           command: npm run test-check-coverage
       - run:
           name: Upload coverage report
-          command: |
-            if node --version | grep -q '^v10'; then
-                bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
-            fi
+          command: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
 
-  node-8:
-    <<: *common-build
+  node-13:
     docker:
-      - image: circleci/node:8
-
-  node-10:
-    <<: *common-build
-    docker:
-      - image: circleci/node:10
-
-  node-11:
-    <<: *common-build
-    docker:
-      - image: circleci/node:11
+      - image: circleci/node:13
+    steps:
+      - *attach-step
+      - run:
+          name: Test
+          command: npm test
 
 workflows:
   version: 2
-  build:
+  verify:
     jobs:
-      - node-8
-      - node-10
-      - node-11
+      - install-dependencies
+      - lint:
+          requires:
+            - install-dependencies
+      - node-10:
+          requires:
+            - install-dependencies
+      - node-12:
+          requires:
+            - install-dependencies
+      - node-13:
+          requires:
+            - install-dependencies


### PR DESCRIPTION
And make the circle config more consistent with the other Sinon projects

#### How to verify

1. Observe that tests are no longer run in Node 8
1. Observe that tests are now run in Node 13